### PR TITLE
Fix: Align RMSE and log RMSE calculations with standard definitions

### DIFF
--- a/test/metrics_st.py
+++ b/test/metrics_st.py
@@ -26,10 +26,10 @@ def compute_depth_metrics(gt, pred, mask=None, median_align=False):
     a3 = (thresh < 1.25 ** 3).float().mean()
 
     rmse = (gt - pred) ** 2
-    rmse = torch.sqrt(rmse).mean()
+    rmse = torch.sqrt(rmse.mean())
 
     rmse_log = (torch.log10(gt) - torch.log10(pred)) ** 2
-    rmse_log = torch.sqrt(rmse_log).mean()
+    rmse_log = torch.sqrt(rmse_log.mean())
 
     abs_ = torch.mean(torch.abs(gt - pred))
 


### PR DESCRIPTION
Hi authors,

Thank you for releasing this excellent work and the highly readable codebase! 
While studying the evaluation metrics, I noticed a minor mathematical detail regarding the `rmse` and `rmse_log` calculations. Currently, taking the square root before the mean effectively computes the Mean Absolute Error (MAE). 
This PR makes a slight adjustment by moving `.mean()` inside `torch.sqrt()`, which aligns the code strictly with the standard mathematical formulation of Root Mean Square Error (RMSE).

Hope this small refinement is helpful to your amazing project. Thanks again for your great contributions to the community!